### PR TITLE
ignore_base_assets

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
             ->booleanNode('copy_images')->defaultFalse()->end()
+            ->booleanNode('ignore_base_assets')->defaultFalse()->end()
             ->end()
         ;
 

--- a/DependencyInjection/TerrificCoreExtension.php
+++ b/DependencyInjection/TerrificCoreExtension.php
@@ -31,9 +31,10 @@ class TerrificCoreExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
         $container->setParameter('terrific_core.resources.copyimages', $config['copy_images']);
+        $container->setParameter('terrific_core.resources.ignore_base_assets', $config['ignore_base_assets']);
     }
 }

--- a/Factory/LazyAssetManager.php
+++ b/Factory/LazyAssetManager.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * User: blorenz
+ * Date: 05.11.12
+ * Time: 08:05
+ * To change this template use File | Settings | File Templates.
+ */
+
+
+namespace Terrific\CoreBundle\Factory {
+
+    /**
+     * Extends default LazyAssetManager to ignore default TerrificAssets.
+     *
+     */
+    class LazyAssetManager extends \Assetic\Factory\LazyAssetManager
+    {
+        public $service;
+
+        /**
+         * @return array
+         */
+        public function getNames()
+        {
+            $ret = parent::getNames();
+
+
+            if ($this->service->getContainer()->getParameter('terrific_core.resources.ignore_base_assets')) {
+                $nRet = array();
+                foreach ($ret as $asset) {
+                    $formula = $this->getFormula($asset);
+
+                    if (isset($formula[2])) {
+                        $data = $formula[2];
+
+                        if ($data["output"] != "css/compiled/base.css" && $data["output"] != "js/compiled/base.js") {
+                            $nRet[] = $asset;
+                        }
+                    }
+                }
+                return $nRet;
+            }
+
+            return $ret;
+        }
+    }
+
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,9 +6,11 @@
 
     <parameters>
         <parameter key="terrific_core.resources.class">Terrific\CoreBundle\EventListener\ResourceListener</parameter>
+        <parameter key="assetic.asset_manager.class">Terrific\CoreBundle\Factory\LazyAssetManager</parameter>
     </parameters>
 
     <services>
+
         <service id="twig.extension.terrific.core"
                  class="Terrific\CoreBundle\Twig\Extension\TerrificCoreExtension" public="true">
             <tag name="twig.extension"/>


### PR DESCRIPTION
terrific_core.ignore_base_assets : (boolean: default false)

If ignore_base_assets is set to true assetic will ignore all
base.js and base.css named files.
