### PR TITLE
Only render the class attribute if 'body_class' is defined

### DIFF
--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -18,7 +18,7 @@
         {% endstylesheets %}
     {% endblock %}
 </head>
-<body class="{% block body_class %}{% endblock %}">
+<body{% if body_class is defined %} class="{% block body_class %}{% endblock %}"{% endif %}>
     {# the content goes here #}
     {% block composition %}{% endblock %}
 


### PR DESCRIPTION
otherwise you'll always have <body class=""> in the markup...
